### PR TITLE
FIX moderation request validation

### DIFF
--- a/commentapi/moderation.go
+++ b/commentapi/moderation.go
@@ -224,7 +224,7 @@ type ActOnClassificationArgs struct {
 // Validate validates the data in the ActOnClassificationArgs
 func (a ActOnClassificationArgs) Validate() api.StatusError {
 	err := v.ValidateStruct(&a,
-		v.Field(&a.CommentID, validator.ClaimID, v.Required),
+		v.Field(&a.CommentID, v.Required),
 	)
 	if err != nil {
 		return api.StatusError{Err: errors.Err(err), Status: http.StatusBadRequest}


### PR DESCRIPTION
I mistakenly thought comments had same regexp as a claim. Since I was using that during testing, I didn't realize that was not true. Currently, the endpoint is dead for real comment_ids.