### PR TITLE
FIX bug and ADD channel watch admin service

### DIFF
--- a/commentapi/moderation.go
+++ b/commentapi/moderation.go
@@ -236,3 +236,37 @@ func (a ActOnClassificationArgs) Validate() api.StatusError {
 type ActOnClassificationResponse struct {
 	Status string `json:"status"`
 }
+
+// AdminAlgoCallbacksArgs Arguments to modify the algo_callbacks table
+type AdminAlgoCallbacksArgs struct {
+	ChannelID string `json:"channel_id"`
+	WatcherID uint   `json:"watcher_id"`
+	Add       bool   `json:"add"`
+}
+
+// InternalWatcherID is the ID of the internal watcher
+const InternalWatcherID = 0
+
+// Validate validates the data in the AdminAlgoCallbacksArgs
+func (a AdminAlgoCallbacksArgs) Validate() api.StatusError {
+	err := v.ValidateStruct(&a,
+		v.Field(&a.ChannelID, v.Required),
+	)
+	if err != nil {
+		return api.StatusError{Err: errors.Err(err), Status: http.StatusBadRequest}
+	}
+
+	if a.WatcherID != InternalWatcherID {
+		return api.StatusError{
+			Err:    errors.Err("user-defined watchers are not supported"),
+			Status: http.StatusBadRequest,
+		}
+	}
+
+	return api.StatusError{}
+}
+
+// AdminAlgoCallbacksResponse response for moderation.AdminAlgoCallbacks
+type AdminAlgoCallbacksResponse struct {
+	Status string `json:"status"`
+}

--- a/http_requests/v2/moderation-adminalgocallbacks.http
+++ b/http_requests/v2/moderation-adminalgocallbacks.http
@@ -1,0 +1,32 @@
+### Add
+POST http://localhost:5900/api/v2
+Content-Type: application/json
+Authorization: Basic api-user api-pass
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "moderation.AdminAlgoCallbacks",
+  "params": {
+    "channel_id": "c9da929d12afe6066acc89eb044b552f0d63782a",
+    "watcher_id": 0,
+    "add": true
+  }
+}
+
+
+### Delete
+POST http://localhost:5900/api/v2
+Content-Type: application/json
+Authorization: Basic api-user api-pass
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "moderation.AdminAlgoCallbacks",
+  "params": {
+    "channel_id": "c9da929d12afe6066acc89eb044b552f0d63782a",
+    "watcher_id": 0,
+    "add": false
+  }
+}

--- a/server/services/v2/moderation/actonclassification.go
+++ b/server/services/v2/moderation/actonclassification.go
@@ -32,7 +32,7 @@ func actOnClassification(r *http.Request, args *commentapi.ActOnClassificationAr
 	err = db.WithTx(db.RW, nil, func(tx boil.Transactor) error {
 		// Delete the comment.
 		if args.DoDelete {
-			err = commentClassification.R.Comment.Delete(db.RW, false)
+			err = commentClassification.R.Comment.Delete(tx, false)
 			if err != nil {
 				return err
 			}
@@ -42,7 +42,7 @@ func actOnClassification(r *http.Request, args *commentapi.ActOnClassificationAr
 		commentClassification.IsReviewed = null.BoolFrom(true)
 		commentClassification.ReviewerApproved = null.BoolFrom(args.Confirm)
 
-		return commentClassification.Update(db.RW, boil.Infer())
+		return commentClassification.Update(tx, boil.Infer())
 	})
 
 	if err != nil {

--- a/server/services/v2/moderation/adminalgocallbacks.go
+++ b/server/services/v2/moderation/adminalgocallbacks.go
@@ -1,0 +1,83 @@
+package moderation
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/OdyseeTeam/commentron/commentapi"
+	"github.com/OdyseeTeam/commentron/db"
+	"github.com/OdyseeTeam/commentron/jobs/commentclassification"
+	"github.com/OdyseeTeam/commentron/model"
+	"github.com/lbryio/lbry.go/v2/extras/errors"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+)
+
+// adminAlgoCallbacks adds or deletes rows from the ChannelAlgoCallbacks table
+//
+// Ideally this would be restful with a PUT and DELETE, but this is such a narrow
+// API surface area that I'd prefer to keep it in one place.
+func adminAlgoCallbacks(r *http.Request, args *commentapi.AdminAlgoCallbacksArgs, reply *commentapi.AdminAlgoCallbacksResponse) error {
+	if err := commentclassification.IsAuthenticated(r); err != nil {
+		return err
+	}
+
+	// Verify that the channel exists.
+	exists, err := model.ChannelExists(db.RO, args.ChannelID)
+	if err != nil {
+		return errors.Err(err)
+	} else if !exists {
+		return errors.Err("channel `%s` does not exist in commentron", args.ChannelID)
+	}
+
+	if args.Add {
+		err := db.WithTx(db.RW, nil, func(tx boil.Transactor) error {
+			// Check if it already exists.
+			exists, err := model.ChannelAlgoCallbacks(
+				model.ChannelAlgoCallbackWhere.ChannelID.EQ(args.ChannelID),
+				model.ChannelAlgoCallbackWhere.WatcherID.EQ(args.WatcherID),
+			).Exists(tx)
+
+			if err != nil {
+				return err
+			} else if exists {
+				return nil
+			}
+
+			// Insert the channel algo callback.
+			callback := &model.ChannelAlgoCallback{
+				ChannelID: args.ChannelID,
+				WatcherID: args.WatcherID,
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			}
+			if err = callback.Insert(tx, boil.Infer()); err != nil {
+				return errors.Err(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return errors.Err(err)
+		}
+		reply.Status = "added"
+	} else {
+		// Delete the channel algo callback.
+		err := db.WithTx(db.RW, nil, func(tx boil.Transactor) error {
+			callback, err := model.ChannelAlgoCallbacks(
+				model.ChannelAlgoCallbackWhere.ChannelID.EQ(args.ChannelID),
+				model.ChannelAlgoCallbackWhere.WatcherID.EQ(args.WatcherID),
+			).One(db.RO)
+
+			if err != nil {
+				return err
+			}
+
+			return callback.Delete(tx)
+		})
+		if err != nil {
+			return errors.Err(err)
+		}
+		reply.Status = "deleted"
+	}
+
+	return nil
+}

--- a/server/services/v2/moderation/service.go
+++ b/server/services/v2/moderation/service.go
@@ -48,3 +48,8 @@ func (s Service) ListDelegates(r *http.Request, args *commentapi.ListDelegatesAr
 func (s Service) ActOnClassification(r *http.Request, args *commentapi.ActOnClassificationArgs, reply *commentapi.ActOnClassificationResponse) error {
 	return actOnClassification(r, args, reply)
 }
+
+// AdminAlgoCallbacks adds or deletes a ChannelAlgoCallback
+func (s Service) AdminAlgoCallbacks(r *http.Request, args *commentapi.AdminAlgoCallbacksArgs, reply *commentapi.AdminAlgoCallbacksResponse) error {
+	return adminAlgoCallbacks(r, args, reply)
+}


### PR DESCRIPTION
There was bug in the actsonclassifier service. The transaction wasn't actually used. It prob would never cause a problem but still. Otherwise, this adds an endpoint to administer which channel's comments should be watched internally for various forms of abuse.