### PR TITLE
Don't unpin comment on edit

### DIFF
--- a/server/services/v1/comments/edit.go
+++ b/server/services/v1/comments/edit.go
@@ -37,7 +37,6 @@ func edit(args *commentapi.EditArgs) (*commentapi.CommentItem, error) {
 	}
 
 	comment.Body = args.Comment
-	comment.IsPinned = false
 	comment.Signature.SetValid(args.Signature)
 	comment.Signingts.SetValid(args.SigningTS)
 	// keep original timestamp for now. Eventually track last edit. Frontend can compare signingts and this.


### PR DESCRIPTION
User complained about comments getting unpinned when editing them.  

Seems it was coded to always unpin on edit. Can't tell if it's required for some reason.