### PR TITLE
Fix slowmode + fiat hyperchats in dryRun

### DIFF
--- a/commentapi/comment.go
+++ b/commentapi/comment.go
@@ -88,6 +88,7 @@ type CreateArgs struct {
 	SigningTS         string             `json:"signing_ts"`
 	MentionedChannels []MentionedChannel `json:"mentioned_channels"`
 	IsProtected       bool               `json:"is_protected"`
+	Amount            *uint64            `json:"amount"`
 	DryRun            bool               `json:"dry_run"`
 }
 


### PR DESCRIPTION
Requires frontend to also sent fake `SupportTxid`/`PaymentIntentID` with the `Amount` for the dryRun. (Should fix fiat hyperchats)

Don't add to slowmode counter when doing a dryRun.