### PR TITLE
Comment create amount from int64 to float64

### DIFF
--- a/commentapi/comment.go
+++ b/commentapi/comment.go
@@ -88,7 +88,7 @@ type CreateArgs struct {
 	SigningTS         string             `json:"signing_ts"`
 	MentionedChannels []MentionedChannel `json:"mentioned_channels"`
 	IsProtected       bool               `json:"is_protected"`
-	Amount            *uint64            `json:"amount"`
+	Amount            *float64           `json:"amount"`
 	DryRun            bool               `json:"dry_run"`
 }
 

--- a/server/services/v1/comments/create.go
+++ b/server/services/v1/comments/create.go
@@ -546,7 +546,7 @@ func checkMinTipAmountComment(settings *m.CreatorSetting, request *createRequest
 		return api.StatusError{Err: errors.Err("you must include LBC tip in order to comment as required by creator"), Status: http.StatusBadRequest}
 	}
 	if request.comment.Amount.Uint64 < settings.MinTipAmountComment.Uint64 {
-		return api.StatusError{Err: errors.Err("you must tip at least %d LBC with this comment as required by %s", settings.MinTipAmountComment.Uint64, request.creatorChannel.Name), Status: http.StatusBadRequest}
+		return api.StatusError{Err: errors.Err("you must tip at least %.2f LBC with this comment as required by %s", btcutil.Amount(settings.MinTipAmountComment.Uint64).ToBTC(), request.creatorChannel.Name), Status: http.StatusBadRequest}
 	}
 	return nil
 }
@@ -556,21 +556,21 @@ func checkMinUsdcTipAmountComment(settings *m.CreatorSetting, request *createReq
 		return api.StatusError{Err: errors.Err("you must include USDC tip in order to comment as required by creator"), Status: http.StatusBadRequest}
 	}
 	if request.comment.Amount.Uint64 < settings.MinUsdcTipAmountComment.Uint64 {
-		return api.StatusError{Err: errors.Err("you must tip at least %d USDC with this comment as required by %s", settings.MinUsdcTipAmountComment.Uint64, request.creatorChannel.Name), Status: http.StatusBadRequest}
+		return api.StatusError{Err: errors.Err("you must tip at least %.2f USDC with this comment as required by %s", float64(settings.MinUsdcTipAmountComment.Uint64)/float64(100), request.creatorChannel.Name), Status: http.StatusBadRequest}
 	}
 	return nil
 }
 
 func checkMinTipAmountSuperChat(settings *m.CreatorSetting, request *createRequest) error {
 	if request.args.PaymentIntentID != nil || request.comment.Amount.Uint64 < settings.MinTipAmountSuperChat.Uint64 {
-		return api.StatusError{Err: errors.Err("a min tip of %d LBC is required to hyperchat", settings.MinTipAmountSuperChat.Uint64), Status: http.StatusBadRequest}
+		return api.StatusError{Err: errors.Err("a min tip of %.2f LBC is required to hyperchat", btcutil.Amount(settings.MinTipAmountSuperChat.Uint64).ToBTC()), Status: http.StatusBadRequest}
 	}
 	return nil
 }
 
 func checkMinUsdcTipAmountSuperChat(settings *m.CreatorSetting, request *createRequest) error {
 	if request.args.PaymentIntentID == nil || request.comment.Amount.Uint64 < settings.MinUsdcTipAmountSuperChat.Uint64 {
-		return api.StatusError{Err: errors.Err("a min tip of %d USDC is required to hyperchat", settings.MinUsdcTipAmountSuperChat.Uint64), Status: http.StatusBadRequest}
+		return api.StatusError{Err: errors.Err("a min tip of %.2f USDC is required to hyperchat", (float64(settings.MinUsdcTipAmountSuperChat.Uint64) / float64(100))), Status: http.StatusBadRequest}
 	}
 	return nil
 }

--- a/server/services/v1/comments/create.go
+++ b/server/services/v1/comments/create.go
@@ -88,7 +88,16 @@ func create(_ *http.Request, args *commentapi.CreateArgs, reply *commentapi.Crea
 	if args.SupportTxID != nil || args.PaymentIntentID != nil {
 		if args.DryRun {
 			if args.Amount != nil {
-				request.comment.Amount.SetValid(*args.Amount)
+				if args.PaymentIntentID != nil {
+					cents := uint64(*args.Amount * 100)
+					request.comment.Amount.SetValid(cents)
+				} else if args.SupportTxID != nil {
+					lbc, err := btcutil.NewAmount(*args.Amount)
+					if err != nil {
+						return errors.Err(err)
+					}
+					request.comment.Amount.SetValid(uint64(lbc.ToUnit(btcutil.AmountSatoshi)))
+				}
 			}
 		} else {
 			err := updateSupportInfo(request)


### PR DESCRIPTION
Makes the amount in comment create to match the rest of the requests. (Settings and responses have amount in float64)

! NOTE ! 
Should be safe to merge. Think this will make dryRun min limit pass with any LBC tip, since frontend is still sending amount in satoshis. But since UI prevents sending of smaller tips, it should be fine as is.
