### PR TITLE
Reactions wipe feature

### DIFF
--- a/commentapi/client.go
+++ b/commentapi/client.go
@@ -75,6 +75,17 @@ func (d *Client) ReactionReact(args ReactArgs) (*ReactResponse, error) {
 	return response, d.call(response, "reaction.React", structs.Map(args))
 }
 
+/////////////////////////
+//  MODERATION SERVICE //
+/////////////////////////
+
+// ModerationWipeReactions deletes all reactions created by a target channel.
+func (d *Client) ModerationWipeReactions(args WipeReactionsArgs) (*WipeReactionsResponse, error) {
+	structs.DefaultTagName = "json"
+	response := new(WipeReactionsResponse)
+	return response, d.call(response, "moderation.WipeReactions", structs.Map(args))
+}
+
 //////////////////////
 //  COMMENT SERVICE //
 //////////////////////

--- a/commentapi/moderation.go
+++ b/commentapi/moderation.go
@@ -51,6 +51,33 @@ type BlockResponse struct {
 	BannedFrom *string `json:"banned_from"`
 }
 
+// WipeReactionsArgs arguments to delete all reactions created by a target channel.
+type WipeReactionsArgs struct {
+	ModAuthorization
+
+	TargetChannelID   string `json:"target_channel_id"`
+	TargetChannelName string `json:"target_channel_name"`
+}
+
+// Validate validates the data in the wipe reactions args.
+func (w WipeReactionsArgs) Validate() api.StatusError {
+	err := v.ValidateStruct(&w,
+		v.Field(&w.TargetChannelID, validator.ClaimID, v.Required),
+		v.Field(&w.ModChannelID, validator.ClaimID, v.Required),
+		v.Field(&w.ModChannelName, v.Required),
+	)
+	if err != nil {
+		return api.StatusError{Err: errors.Err(err), Status: http.StatusBadRequest}
+	}
+	return api.StatusError{}
+}
+
+// WipeReactionsResponse response for the moderation.WipeReactions rpc call.
+type WipeReactionsResponse struct {
+	TargetChannelID      string `json:"target_channel_id"`
+	DeletedReactionCount uint64 `json:"deleted_reaction_count"`
+}
+
 // AmIArgs Arguments to check whether a user is a moderator or not
 type AmIArgs struct {
 	Authorization

--- a/server/services/v2/moderation/service.go
+++ b/server/services/v2/moderation/service.go
@@ -29,6 +29,11 @@ func (s Service) BlockedList(r *http.Request, args *commentapi.BlockedListArgs, 
 	return blockedList(r, args, reply)
 }
 
+// WipeReactions deletes all reactions created by a target channel.
+func (s Service) WipeReactions(r *http.Request, args *commentapi.WipeReactionsArgs, reply *commentapi.WipeReactionsResponse) error {
+	return wipeReactions(r, args, reply)
+}
+
 // AddDelegate return the list of blocked channels for a moderator
 func (s Service) AddDelegate(r *http.Request, args *commentapi.AddDelegateArgs, reply *commentapi.ListDelegateResponse) error {
 	return addDelegate(r, args, reply)

--- a/server/services/v2/moderation/wipe_reactions.go
+++ b/server/services/v2/moderation/wipe_reactions.go
@@ -1,0 +1,49 @@
+package moderation
+
+import (
+	"net/http"
+
+	"github.com/OdyseeTeam/commentron/commentapi"
+	"github.com/OdyseeTeam/commentron/db"
+	"github.com/OdyseeTeam/commentron/model"
+	"github.com/OdyseeTeam/commentron/server/auth"
+
+	"github.com/aarondl/null/v8"
+	"github.com/lbryio/lbry.go/v2/extras/api"
+	"github.com/lbryio/lbry.go/v2/extras/errors"
+)
+
+func wipeReactions(r *http.Request, args *commentapi.WipeReactionsArgs, reply *commentapi.WipeReactionsResponse) error {
+	modChannel, _, _, err := auth.ModAuthenticate(r, &args.ModAuthorization)
+	if err != nil {
+		return err
+	}
+
+	isMod, err := modChannel.ModChannelModerators().Exists(db.RO)
+	if err != nil {
+		return errors.Err(err)
+	}
+	if !isMod {
+		return api.StatusError{Err: errors.Err("cannot wipe reactions without admin privileges"), Status: http.StatusForbidden}
+	}
+
+	reactions, err := model.Reactions(
+		model.ReactionWhere.ChannelID.EQ(null.StringFrom(args.TargetChannelID)),
+	).All(db.RO)
+	if err != nil {
+		return errors.Err(err)
+	}
+
+	reply.TargetChannelID = args.TargetChannelID
+	reply.DeletedReactionCount = uint64(len(reactions))
+	if len(reactions) == 0 {
+		return nil
+	}
+
+	err = reactions.DeleteAll(db.RW)
+	if err != nil {
+		return errors.Err(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Allows for mods to wipe reactions given by a channel in addition to the current comments delete / wipe. 